### PR TITLE
Fix CLI imports and preprocessing

### DIFF
--- a/build_quantity.py
+++ b/build_quantity.py
@@ -8,8 +8,8 @@ from sklearn.pipeline import Pipeline
 from sklearn.ensemble import RandomForestRegressor
 from sklearn.model_selection import train_test_split
 
-from qualitylab.ml.feature_engineering import merge_downtime_features
-from qualitylab.io.spreadsheets         import read_downtime_data
+from feature_engineering import merge_downtime_features
+from spreadsheets import read_downtime_data
 
 def train_build_quantity_model(
     df_prod: pd.DataFrame,

--- a/build_time.py
+++ b/build_time.py
@@ -8,7 +8,7 @@ from sklearn.pipeline import Pipeline
 from sklearn.ensemble import RandomForestRegressor
 from sklearn.model_selection import train_test_split
 
-from qualitylab.ml.feature_engineering import add_recent_history
+from feature_engineering import add_recent_history
 
 def train_build_time_model(df: pd.DataFrame) -> Pipeline:
     """

--- a/defects.py
+++ b/defects.py
@@ -9,7 +9,7 @@ from sklearn.ensemble import RandomForestRegressor
 from sklearn.multioutput import MultiOutputRegressor
 from sklearn.model_selection import train_test_split
 
-from qualitylab.ml.feature_engineering import add_recent_history
+from feature_engineering import add_recent_history
 
 def train_defect_model(df: pd.DataFrame) -> Pipeline:
     """

--- a/spreadsheets.py
+++ b/spreadsheets.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+import pandas as pd
+
+
+def _read_one(path: Path) -> pd.DataFrame:
+    """Read a single spreadsheet (CSV or Excel) into a DataFrame."""
+    if path.suffix.lower() == ".csv":
+        return pd.read_csv(path)
+    return pd.read_excel(path)
+
+
+def read_production_data(paths: list[Path]) -> pd.DataFrame:
+    """Load and concatenate production data from multiple files."""
+    frames = [_read_one(Path(p)) for p in paths]
+    return pd.concat(frames, ignore_index=True)
+
+
+def read_downtime_data(paths: list[Path]) -> pd.DataFrame:
+    """Load and concatenate downtime data from multiple files."""
+    frames = [_read_one(Path(p)) for p in paths]
+    return pd.concat(frames, ignore_index=True)
+

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -7,7 +7,7 @@ import seaborn as sns
 import matplotlib.pyplot as plt
 import joblib
 from lime.lime_tabular import LimeTabularExplainer
-from qualitylab.ml.feature_engineering import add_recent_history, merge_downtime_features
+from feature_engineering import add_recent_history, merge_downtime_features
 from upsetplot import from_indicators, UpSet
 
 


### PR DESCRIPTION
## Summary
- fix CLI imports to reference local modules
- avoid double feature engineering during training
- add data I/O helpers
- update imports across modules

## Testing
- `python -m py_compile cli.py build_time.py build_quantity.py defects.py feature_engineering.py streamlit_app.py spreadsheets.py`
- `python cli.py --help`


------
https://chatgpt.com/codex/tasks/task_e_6861c8ec6fbc832bb4e87c5bf096f4be