### PR TITLE
Fix broken module references

### DIFF
--- a/build_quantity.py
+++ b/build_quantity.py
@@ -8,8 +8,8 @@ from sklearn.pipeline import Pipeline
 from sklearn.ensemble import RandomForestRegressor
 from sklearn.model_selection import train_test_split
 
-from qualitylab.ml.feature_engineering import merge_downtime_features
-from qualitylab.io.spreadsheets         import read_downtime_data
+from feature_engineering import merge_downtime_features
+from spreadsheets import read_downtime_data
 
 def train_build_quantity_model(
     df_prod: pd.DataFrame,

--- a/build_time.py
+++ b/build_time.py
@@ -8,7 +8,7 @@ from sklearn.pipeline import Pipeline
 from sklearn.ensemble import RandomForestRegressor
 from sklearn.model_selection import train_test_split
 
-from qualitylab.ml.feature_engineering import add_recent_history
+from feature_engineering import add_recent_history
 
 def train_build_time_model(df: pd.DataFrame) -> Pipeline:
     """

--- a/cli.py
+++ b/cli.py
@@ -2,11 +2,11 @@ import click
 from pathlib import Path
 import pandas as pd
 import joblib
-from qualitylab.io.spreadsheets import read_production_data
-from qualitylab.ml.feature_engineering import add_recent_history
-from qualitylab.ml.build_time import train_build_time_model
-from qualitylab.ml.build_quantity import train_build_quantity_model
-from qualitylab.ml.defects import train_defect_model
+from spreadsheets import read_production_data
+from feature_engineering import add_recent_history
+from build_time import train_build_time_model
+from build_quantity import train_build_quantity_model
+from defects import train_defect_model
 
 # Paths relative to this package
 PACKAGE_ROOT = Path(__file__).resolve().parent

--- a/defects.py
+++ b/defects.py
@@ -9,7 +9,7 @@ from sklearn.ensemble import RandomForestRegressor
 from sklearn.multioutput import MultiOutputRegressor
 from sklearn.model_selection import train_test_split
 
-from qualitylab.ml.feature_engineering import add_recent_history
+from feature_engineering import add_recent_history
 
 def train_defect_model(df: pd.DataFrame) -> Pipeline:
     """

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,15 @@ from setuptools import setup, find_packages
 setup(
     name="qualitylab",
     version="0.1.0",
-    packages=find_packages(),
+    py_modules=[
+        "build_time",
+        "build_quantity",
+        "defects",
+        "feature_engineering",
+        "cli",
+        "spreadsheets",
+        "streamlit_app",
+    ],
     install_requires=[
         "pandas",
         "scikit-learn",
@@ -16,7 +24,7 @@ setup(
     ],
     entry_points={
         "console_scripts": [
-            "qualitylab=qualitylab.cli:cli",
+            "qualitylab=cli:cli",
         ]
     }
 )

--- a/spreadsheets.py
+++ b/spreadsheets.py
@@ -1,0 +1,65 @@
+import pandas as pd
+from pathlib import Path
+
+def _read_file(path: Path) -> pd.DataFrame:
+    if str(path).lower().endswith((".xlsx", ".xls")):
+        return pd.read_excel(path, engine="openpyxl")
+    else:
+        return pd.read_csv(path)
+
+def read_production_data(paths: list[Path]) -> pd.DataFrame:
+    """Read and concatenate production sheets from given paths."""
+    frames = [_read_file(p) for p in paths]
+    df = pd.concat(frames, ignore_index=True)
+    df.columns = (
+        df.columns
+          .str.strip()
+          .str.lower()
+          .str.replace(r"[ _]+", "_", regex=True)
+    )
+    for col in ("build_start_date", "build_complete_date"):
+        if col in df.columns:
+            df[col] = pd.to_datetime(df[col], errors="coerce")
+    if "build_start_date" in df.columns and "build_complete_date" in df.columns:
+        df = df.dropna(subset=["build_start_date", "build_complete_date"])
+        df["build_time_days"] = (
+            df["build_complete_date"] - df["build_start_date"]
+        ).dt.total_seconds() / 86400
+    if "line" in df.columns:
+        df["line"] = df["line"].astype(str).str.strip().str.upper()
+    if "part_number" in df.columns:
+        df["part_number"] = df["part_number"].astype(str).str.strip()
+    defect_cols = [c for c in df.columns if c.startswith("qty_of_defect_")]
+    for c in defect_cols:
+        df[c] = pd.to_numeric(df[c], errors="coerce").fillna(0)
+    return df
+
+def read_downtime_data(paths: list[Path]) -> pd.DataFrame:
+    """Read and concatenate downtime logs from given paths."""
+    frames = [_read_file(p) for p in paths]
+    df = pd.concat(frames, ignore_index=True)
+    df.columns = (
+        df.columns
+          .str.strip()
+          .str.lower()
+          .str.replace(r"[ _]+", "_", regex=True)
+    )
+    if "date" in df.columns:
+        df["date"] = pd.to_datetime(df["date"], errors="coerce")
+        df = df.dropna(subset=["date"])
+    if "line" in df.columns:
+        df["line"] = df["line"].astype(str).str.strip().str.upper()
+    if "failure_mode" in df.columns:
+        df["failure_mode"] = (
+            df["failure_mode"]
+              .astype(str)
+              .str.strip()
+              .str.upper()
+              .str.replace(r"^\d+\s*-\s*", "", regex=True)
+        )
+    else:
+        df["failure_mode"] = "NONE"
+    for col in ("downtime_min", "opportunity_cost"):
+        if col in df.columns:
+            df[col] = pd.to_numeric(df[col], errors="coerce").fillna(0)
+    return df

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -7,7 +7,7 @@ import seaborn as sns
 import matplotlib.pyplot as plt
 import joblib
 from lime.lime_tabular import LimeTabularExplainer
-from qualitylab.ml.feature_engineering import add_recent_history, merge_downtime_features
+from feature_engineering import add_recent_history, merge_downtime_features
 from upsetplot import from_indicators, UpSet
 
 
@@ -17,7 +17,7 @@ st.set_page_config(layout="centered")
 sns.set(rc={"figure.figsize": (16, 9)})
 
 # Ensure project root on path
-project_root = Path(__file__).parents[2]
+project_root = Path(__file__).resolve().parent
 sys.path.insert(0, str(project_root))
 
 def get_latest_model(pattern: str) -> Path:


### PR DESCRIPTION
## Summary
- update imports to use local modules instead of missing `qualitylab` package
- adjust project root calculation in Streamlit app
- add a `spreadsheets` utility with helpers to read production and downtime sheets
- package modules via `py_modules` and fix CLI entrypoint

## Testing
- `python -m py_compile $(ls *.py)`
- `flake8 *.py`

------
https://chatgpt.com/codex/tasks/task_e_6861c8a51cf0832b803fc6f75f0f8da3