### PR TITLE
Fix plan build_time filling and streamline CLI

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -33,16 +33,14 @@ def ingest(files):
 def train_build_time():
     data_path = get_data_dir() / "production.parquet"
     df = pd.read_parquet(data_path)
-    df_fe = add_recent_history(df)
-    train_build_time_model(df_fe)
+    train_build_time_model(df)
     click.echo("✅ Build-time model trained")
 
 @cli.command("train-defects")
 def train_defects():
     data_path = get_data_dir() / "production.parquet"
     df = pd.read_parquet(data_path)
-    df_fe = add_recent_history(df)
-    train_defect_model(df_fe)
+    train_defect_model(df)
     click.echo("✅ Defect model trained")
 
 @cli.command('train-build-quantity')

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -188,8 +188,18 @@ if "plan_end_date" in df_plan.columns:
 else:
     df_plan["plan_end_date"] = df_plan["plan_start_date"]
 auto_bt = (df_plan["plan_end_date"] - df_plan["plan_start_date"]).dt.total_seconds() / 86400
-df_plan["build_time_days"] = df_plan.get("build_time_days", auto_bt)
-df_plan = df_plan.dropna(subset=["part_number", "planned_qty", "plan_start_date", "build_time_days"])
+if "build_time_days" in df_plan.columns:
+    df_plan["build_time_days"] = df_plan["build_time_days"].fillna(auto_bt)
+else:
+    df_plan["build_time_days"] = auto_bt
+
+df_plan = df_plan.dropna(subset=[
+    "part_number",
+    "planned_qty",
+    "plan_start_date",
+    "plan_end_date",
+    "build_time_days",
+])
 if "line" not in df_plan.columns:
     st.error("Missing 'line' in build plan")
     st.stop()


### PR DESCRIPTION
## Summary
- fill missing plan `build_time_days` values with auto-calculated duration
- drop plan rows missing required dates
- avoid redundant feature engineering when using the CLI

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862008a56e8832ba274b25425818790