### PR TITLE
Add downtime ingestion and train-all command

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,15 @@ directory and are automatically loaded by the Streamlit dashboard.
    The command concatenates the provided files and writes a
    `data/production.parquet` file inside the project directory.
 
-2. **Train the build-time model**
+2. **Ingest the downtime logs**
+
+   ```bash
+   qualitylab ingest-downtime path/to/downtime_log1.xlsx path/to/downtime_log2.csv
+   ```
+
+   This writes a `data/downtime.parquet` file used for build quantity training.
+
+3. **Train the build-time model**
 
    ```bash
    qualitylab train-build-time
@@ -41,20 +49,22 @@ directory and are automatically loaded by the Streamlit dashboard.
 
    A timestamped model is saved under `models/`.
 
-3. **Train the defect-count model**
+4. **Train the defect-count model**
 
    ```bash
    qualitylab train-defects
    ```
 
-4. **Train the build-quantity model**
-
+5. **Train the build-quantity model**
    ```bash
-   qualitylab train-build-quantity path/to/prod1.xlsx path/to/prod2.csv \
-       --downtime-files downtime_log1.xlsx --downtime-files downtime_log2.csv
+   qualitylab train-build-quantity
    ```
 
-   Both production and downtime files are required for this step.
+6. **Train all models at once**
+
+   ```bash
+   qualitylab train-all
+   ```
 
 After running these commands the `models/` directory will contain the latest
 training artefacts.

--- a/build_quantity.py
+++ b/build_quantity.py
@@ -9,11 +9,10 @@ from sklearn.ensemble import RandomForestRegressor
 from sklearn.model_selection import train_test_split
 
 from feature_engineering import merge_downtime_features
-from spreadsheets import read_downtime_data
 
 def train_build_quantity_model(
     df_prod: pd.DataFrame,
-    downtime_paths: list[Path]
+    df_down: pd.DataFrame,
 ) -> Pipeline:
     """
     Train a model to predict feasible production quantity per build,
@@ -21,10 +20,9 @@ def train_build_quantity_model(
     plus categorical columns: part_number, line, and failure_mode.
 
     df_prod: production DataFrame AFTER add_recent_history(df_prod).
-    downtime_paths: list of Excel/CSV files with downtime logs.
+    df_down: pre-loaded downtime DataFrame.
     """
     # 1) Merge in downtime features
-    df_down = read_downtime_data(downtime_paths)
     df = merge_downtime_features(df_prod, df_down)
 
     # 2) Compute defect_rate from *all* qty_of_defect_* columns

--- a/cli.py
+++ b/cli.py
@@ -2,7 +2,7 @@ import click
 from pathlib import Path
 import pandas as pd
 import joblib
-from spreadsheets import read_production_data
+from spreadsheets import read_production_data, read_downtime_data
 from feature_engineering import add_recent_history
 from build_time import train_build_time_model
 from build_quantity import train_build_quantity_model
@@ -29,6 +29,14 @@ def ingest(files):
     df.to_parquet(out_dir / "production.parquet")
     click.echo("✅ Ingested")
 
+@cli.command("ingest-downtime")
+@click.argument("files", nargs=-1, type=click.Path(exists=True))
+def ingest_downtime(files):
+    df = read_downtime_data([Path(f) for f in files])
+    out_dir = get_data_dir()
+    df.to_parquet(out_dir / "downtime.parquet")
+    click.echo("✅ Downtime ingested")
+
 @cli.command("train-build-time")
 def train_build_time():
     data_path = get_data_dir() / "production.parquet"
@@ -43,26 +51,28 @@ def train_defects():
     train_defect_model(df)
     click.echo("✅ Defect model trained")
 
-@cli.command('train-build-quantity')
-@click.argument('prod_files', nargs=-1, type=click.Path(exists=True))
-@click.option(
-    '--downtime-files', '-d',
-    multiple=True,
-    type=click.Path(exists=True),
-    required=True,
-    help="Paths to downtime sheets (xlsx or csv)."
-)
-def train_build_quantity(prod_files, downtime_files):
-     # ingest production & downtime
-    df_prod = read_production_data([Path(f) for f in prod_files])
-    df_prod = add_recent_history(df_prod)
-    # train and save
-    train_build_quantity_model(
-        df_prod,
-        [Path(f) for f in downtime_files]
-    )
-    click.echo("✅ Build-quantity model trained")
+@cli.command("train-all")
+def train_all():
+    """Train all models in sequence."""
+    train_build_time()
+    train_defects()
+    train_build_quantity()
 
+
+@cli.command('train-build-quantity')
+def train_build_quantity():
+    data_dir = get_data_dir()
+    prod_path = data_dir / 'production.parquet'
+    down_path = data_dir / 'downtime.parquet'
+    if not prod_path.exists():
+        raise click.ClickException('Production data not found. Run "qualitylab ingest" first.')
+    if not down_path.exists():
+        raise click.ClickException('Downtime data not found. Run "qualitylab ingest-downtime" first.')
+    df_prod = pd.read_parquet(prod_path)
+    df_prod = add_recent_history(df_prod)
+    df_down = pd.read_parquet(down_path)
+    train_build_quantity_model(df_prod, df_down)
+    click.echo("✅ Build-quantity model trained")
 
 if __name__ == "__main__":
     cli()


### PR DESCRIPTION
## Summary
- support ingesting downtime logs
- add train-all command
- make build-quantity training use ingested data
- update documentation for new CLI commands

## Testing
- `python -m py_compile cli.py build_quantity.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68622189aad8832b8345502985faf2c0