### PR TITLE
Fix missing dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,10 @@ exports are written to `outputs/`.
    ```
 
    This installs a `qualitylab` console script that provides commands for
-   ingesting data and training the models.
+   ingesting data and training the models. The package requires the
+   additional libraries `lime` and `upsetplot` for model explainability
+   and visualisations, which are installed automatically via the
+   `setup.py` requirements.
 
 2. **Prepare your data**
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,9 @@ setup(
         "matplotlib",
         "joblib",
         "openpyxl",
-        "xlrd"
+        "xlrd",
+        "lime",
+        "upsetplot"
     ],
     entry_points={
         "console_scripts": [


### PR DESCRIPTION
## Summary
- add lime and upsetplot to setup requirements
- document these extra dependencies in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68627c857d48832b9b6670e9286b2ad9