### PR TITLE
Remove leftover opportunity_cost references

### DIFF
--- a/qualitylab/build_quantity.py
+++ b/qualitylab/build_quantity.py
@@ -16,7 +16,7 @@ def train_build_quantity_model(
 ) -> Pipeline:
     """
     Train a model to predict feasible production quantity per build,
-    given historical build-time features, defect rate, downtime/opportunity cost,
+    given historical build-time features, defect rate and downtime,
     plus categorical columns: part_number, line, and failure_mode.
 
     df_prod: production DataFrame AFTER add_recent_history(df_prod).

--- a/qualitylab/streamlit_app.py
+++ b/qualitylab/streamlit_app.py
@@ -266,7 +266,7 @@ def make_plan_features(r):
     # Compute 4-week average build time
     bt_4w = hist["build_time_days"].mean() if not hist.empty else 0.0
 
-    # 2) Downtime and opportunity cost during this build plan
+    # 2) Downtime during this build plan
     segment = df_down[
         (df_down.line == ln) &
         (df_down.date.between(st_dt, r.plan_end_date))


### PR DESCRIPTION
## Summary
- remove outdated mention of opportunity cost in Streamlit app comments
- update build quantity docstring to drop opportunity cost reference

## Testing
- `pip install -e .`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686351a4512c832b8ae5101539b5f8d3