### PR TITLE
Pin scikit-learn 1.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ exports are written to `outputs/`.
    additional libraries for model explainability and visualisations.  All
    dependencies are listed in `requirements.txt` so services like
    Streamlit Cloud can install them automatically.
+   The pre-trained models were generated with `scikit-learn==1.6.1`, so
+   ensure that this version is installed to avoid compatibility issues.
 
 2. **Prepare your data**
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pandas
-scikit-learn
+scikit-learn==1.6.1
 streamlit
 seaborn
 matplotlib

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     install_requires=[
         "pandas",
         "numpy",
-        "scikit-learn",
+        "scikit-learn==1.6.1",
         "streamlit",
         "seaborn",
         "matplotlib",


### PR DESCRIPTION
## Summary
- pin `scikit-learn==1.6.1` in requirements and setup.py
- mention the exact version in README setup instructions

## Testing
- `pip install -e .`
- `streamlit --version`


------
https://chatgpt.com/codex/tasks/task_e_686366f69858832bb05ffc3a0128dc67