### PR TITLE
Fix downtime reason logic

### DIFF
--- a/qualitylab/streamlit_app.py
+++ b/qualitylab/streamlit_app.py
@@ -712,8 +712,11 @@ with t2:
                             raw_col = raw_col.split(op)[0].strip()
                             break
 
-                    # for downtime, pull the actual modes you stored
+                    # for downtime, only show when downtime actually occurred
                     if raw_col == "downtime_min":
+                        # skip if there was no downtime or no recorded modes
+                        if r.get("downtime_min", 0) <= 0 or str(r.get("failure_modes", "")).upper() == "NONE":
+                            continue
                         # r["failure_modes"] is the comma-joined list you built above
                         reason = f"{pretty_feat(raw_col)} (mode(s): {r['failure_modes']})"
                     elif cat is not None:


### PR DESCRIPTION
## Summary
- filter out downtime reason when downtime was zero or no modes were logged

## Testing
- `pip install -q -r requirements.txt`
- `python -m compileall -q qualitylab`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68636b67a744832b94759ead3bb5415d