### PR TITLE
Fix downtime NONE reason display

### DIFF
--- a/qualitylab/streamlit_app.py
+++ b/qualitylab/streamlit_app.py
@@ -715,7 +715,8 @@ with t2:
                     # for downtime, only show when downtime actually occurred
                     if raw_col == "downtime_min":
                         # skip if there was no downtime or no recorded modes
-                        if r.get("downtime_min", 0) <= 0 or str(r.get("failure_modes", "")).upper() == "NONE":
+                        fm = str(r.get("failure_modes", "")).strip().upper()
+                        if r.get("downtime_min", 0) <= 0 or fm in ("", "NONE", "NAN"):
                             continue
                         # r["failure_modes"] is the comma-joined list you built above
                         reason = f"{pretty_feat(raw_col)} (mode(s): {r['failure_modes']})"


### PR DESCRIPTION
## Summary
- avoid showing `downtime (mode(s): NONE)` in shortfall reason table

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68637357c340832ba85429abff7ad2a5